### PR TITLE
top_page.scss 微調整

### DIFF
--- a/app/assets/stylesheets/top_page.scss
+++ b/app/assets/stylesheets/top_page.scss
@@ -185,7 +185,7 @@ main {
 }
 
 .pickup__container .items__container .items_box {
-  margin: 0 0 0 20px;
+  margin: 0 0 20px 20px;
   width: 213px;
   float: left;
 }


### PR DESCRIPTION
# WHAT 
top_page.scss
.pickup__container .items__container .items_box

margin: 0 0 0 20px;から
margin: 0 0 20px 20px;
に変更しました。

# WHY
商品が表示される際
商品同士の上下の隙間がなかったため調整しました。
